### PR TITLE
v1.4.3

### DIFF
--- a/App.config
+++ b/App.config
@@ -11,7 +11,7 @@
                 <value>False</value>
             </setting>
             <setting name="UserAgent" serializeAs="String">
-                <value>Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36</value>
+                <value>Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36 Edg/109.0.1518.70</value>
             </setting>
             <setting name="BrowserItemIndex" serializeAs="String">
                 <value>0</value>

--- a/FMain.cs
+++ b/FMain.cs
@@ -66,6 +66,10 @@ public partial class FMain : Form
             {
                 tempValue = await CustomFunction.GetYtChannelIdByYtChannelCustomUrl(tempValue) ?? string.Empty;
             }
+            else if (tempValue.Contains($"@"))
+            {
+                tempValue = await CustomFunction.GetYtChannelIdByYtChannelCustomUrl(tempValue) ?? string.Empty;
+            }
 
             TBChannelID.Text = tempValue;
         });

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace YTLiveChatCatcher.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.3.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.4.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -38,7 +38,7 @@ namespace YTLiveChatCatcher.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) " +
-            "Chrome/107.0.0.0 Safari/537.36")]
+            "Chrome/109.0.0.0 Safari/537.36 Edg/109.0.1518.70")]
         public string UserAgent {
             get {
                 return ((string)(this["UserAgent"]));

--- a/Properties/Settings.settings
+++ b/Properties/Settings.settings
@@ -6,7 +6,7 @@
       <Value Profile="(Default)">False</Value>
     </Setting>
     <Setting Name="UserAgent" Type="System.String" Scope="User">
-      <Value Profile="(Default)">Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36</Value>
+      <Value Profile="(Default)">Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36 Edg/109.0.1518.70</Value>
     </Setting>
     <Setting Name="BrowserItemIndex" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">0</Value>

--- a/YTLiveChatCatcher.csproj
+++ b/YTLiveChatCatcher.csproj
@@ -7,7 +7,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UseWindowsForms>true</UseWindowsForms>
 		<RootNamespace>YTLiveChatCatcher</RootNamespace>
-		<Version>1.4.2</Version>
+		<Version>1.4.3</Version>
 		<AssemblyName>YTLiveChatCatcher</AssemblyName>
 		<ApplicationIcon>Resources\app_icon_large.ico</ApplicationIcon>
 		<DebugType>embedded</DebugType>
@@ -18,14 +18,14 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AngleSharp" Version="0.17.1" />
-		<PackageReference Include="EPPlus" Version="6.1.0" />
-		<PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.0" />
+		<PackageReference Include="AngleSharp" Version="1.0.1" />
+		<PackageReference Include="EPPlus" Version="6.1.2" />
+		<PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.2" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="7.0.0" />
-		<PackageReference Include="NLog" Version="5.0.5" />
-		<PackageReference Include="NLog.Extensions.Logging" Version="5.1.0" />
+		<PackageReference Include="NLog" Version="5.1.1" />
+		<PackageReference Include="NLog.Extensions.Logging" Version="5.2.1" />
 		<PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
 	</ItemGroup>
 


### PR DESCRIPTION
1. 更新第三方函式庫。
2. 更新預設的使用者代理字串。
3. 讓頻道 ID 欄位支援 YouTube 帳號代碼。