### PR TITLE
v1.4.10

### DIFF
--- a/App.config
+++ b/App.config
@@ -17,7 +17,7 @@
                 <value>Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36</value>
             </setting>
             <setting name="BrowserItemIndex" serializeAs="String">
-                <value>1</value>
+                <value>3</value>
             </setting>
             <setting name="ProfileFolderName" serializeAs="String">
                 <value />

--- a/Common/BetterCacheManager.cs
+++ b/Common/BetterCacheManager.cs
@@ -4,8 +4,11 @@ namespace GetCachable;
 
 /// <summary>
 /// BetterCacheManager
-/// <para>參考：https://blog.darkthread.net/blog/improved-getcachabledata/ </para>
-/// <para>參考：https://blog.darkthread.net/blog/cachable-data-object </para>
+/// <para>來源 1：https://blog.darkthread.net/blog/improved-getcachabledata/</para>
+/// <para>來源 2：https://blog.darkthread.net/blog/cachable-data-object</para>
+/// <para>原作者：黑暗執行緒</para>
+/// <para>原授權：CC BY-NC-SA 3.0 TW</para>
+/// <para>CC BY-NC-SA 3.0 TW：https://creativecommons.org/licenses/by-nc-sa/3.0/tw/</para>
 /// </summary>
 public class BetterCacheManager
 {

--- a/Common/CustomFunction.cs
+++ b/Common/CustomFunction.cs
@@ -55,7 +55,10 @@ public class CustomFunction
 
     /// <summary>
     /// 移除檔案路徑中的無效字元
-    /// <para>來源：https://stackoverflow.com/a/8626562 </para>
+    /// <para>來源：https://stackoverflow.com/a/8626562</para>
+    /// <para>原作者：Gary Kindel</para>
+    /// <para>原授權：CC BY-SA 3.0</para>
+    /// <para>CC BY-SA 3.0：https://creativecommons.org/licenses/by-sa/3.0/</para>
     /// </summary>
     /// <param name="filename">字串，檔案名稱</param>
     /// <param name="replaceChar">字串，替換無效字元的字元</param>
@@ -80,8 +83,10 @@ public class CustomFunction
 
     /// <summary>
     /// 開啟網頁瀏覽器
-    /// <para>參考 1：https://github.com/dotnet/runtime/issues/17938#issuecomment-235502080 </para>
-    /// <para>參考 2：https://github.com/dotnet/runtime/issues/17938#issuecomment-249383422 </para>
+    /// <para>來源 1：https://github.com/dotnet/runtime/issues/17938#issuecomment-235502080</para>
+    /// <para>原作者：mellinoe</para>
+    /// <para>來源 2：https://github.com/dotnet/runtime/issues/17938#issuecomment-249383422</para>
+    /// <para>原作者：brockallen</para>
     /// </summary>
     /// <param name="url">字串，網址</param>
     public static void OpenBrowser(string url)

--- a/Common/DesignerBlocker.cs
+++ b/Common/DesignerBlocker.cs
@@ -4,7 +4,10 @@ namespace YTLiveChatCatcher.Common;
 
 /// <summary>
 /// 設計阻擋器
-/// <para>來源：https://stackoverflow.com/a/68585095 </para>
+/// <para>來源：https://stackoverflow.com/a/68585095</para>
+/// <para>原作者：Regular Jo</para>
+/// <para>原授權：CC BY-SA 4.0</para>
+/// <para>CC BY-SA 4.0：https://creativecommons.org/licenses/by-sa/4.0/</para>
 /// </summary>
 [DesignerCategory("")]
 public class DesignerBlocker { }

--- a/Common/Utils/WebBrowserUtil.cs
+++ b/Common/Utils/WebBrowserUtil.cs
@@ -11,7 +11,10 @@ namespace YTLiveChatCatcher.Common.Utils;
 
 /// <summary>
 /// 網頁瀏覽器工具
-/// <para>參考：https://stackoverflow.com/a/68703365 </para>
+/// <para>來源：https://stackoverflow.com/a/68703365</para>
+/// <para>原作者：Flint Charles</para>
+/// <para>原授權：CC BY-SA 4.0</para>
+/// <para>CC BY-SA 4.0：https://creativecommons.org/licenses/by-sa/4.0/</para>
 /// </summary>
 public class WebBrowserUtil
 {
@@ -78,8 +81,7 @@ public class WebBrowserUtil
         /// </summary>
         OperaBeta = 13,
         /// <summary>
-        /// Opera Developer (Opera One)
-        /// <para>僅西元 2023 年</para>
+        /// Opera Developer
         /// </summary>
         OperaDeveloper = 14,
         /// <summary>

--- a/Common/Utils/WebBrowserUtil.cs
+++ b/Common/Utils/WebBrowserUtil.cs
@@ -7,13 +7,13 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 
-namespace YTLiveChatCatcher.Common;
+namespace YTLiveChatCatcher.Common.Utils;
 
 /// <summary>
-/// BrowserManager
+/// 網頁瀏覽器工具
 /// <para>參考：https://stackoverflow.com/a/68703365 </para>
 /// </summary>
-public class BrowserManager
+public class WebBrowserUtil
 {
     /// <summary>
     /// NLog 的 Logger
@@ -21,7 +21,7 @@ public class BrowserManager
     private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
 
     /// <summary>
-    /// 網頁瀏覽器
+    /// 列舉：網頁瀏覽器類型
     /// </summary>
     public enum BrowserType
     {
@@ -30,33 +30,76 @@ public class BrowserManager
         /// </summary>
         Brave = 1,
         /// <summary>
+        /// Brave Beta
+        /// </summary>
+        BraveBeta = 2,
+        /// <summary>
+        /// Brave Nightly
+        /// </summary>
+        BraveNightly = 3,
+        /// <summary>
         /// Google Chrome
         /// </summary>
-        GoogleChrome = 2,
+        GoogleChrome = 4,
+        /// <summary>
+        /// Google Chrome Beta
+        /// </summary>
+        GoogleChromeBeta = 5,
+        /// <summary>
+        /// Google Chrome Canary
+        /// </summary>
+        GoogleChromeCanary = 6,
         /// <summary>
         /// Chromium
         /// </summary>
-        Chromium = 3,
+        Chromium = 7,
         /// <summary>
         /// Microsoft Edge
         /// </summary>
-        MicrosoftEdge = 4,
+        MicrosoftEdge = 8,
+        /// <summary>
+        /// Microsoft Edge Insider Beta
+        /// </summary>
+        MicrosoftEdgeInsiderBeta = 9,
+        /// <summary>
+        /// Microsoft Edge Insider Dev
+        /// </summary>
+        MicrosoftEdgeInsiderDev = 10,
+        /// <summary>
+        /// Microsoft Edge Insider Canary
+        /// </summary>
+        MicrosoftEdgeInsiderCanary = 11,
         /// <summary>
         /// Opera
         /// </summary>
-        Opera = 5,
+        Opera = 12,
+        /// <summary>
+        /// Opera Beta
+        /// </summary>
+        OperaBeta = 13,
+        /// <summary>
+        /// Opera Developer (Opera One)
+        /// <para>僅西元 2023 年</para>
+        /// </summary>
+        OperaDeveloper = 14,
         /// <summary>
         /// Opera GX
         /// </summary>
-        OperaGX = 6,
+        OperaGX = 15,
+        /// <summary>
+        /// Opera Crypto
+        /// </summary>
+        OperaCrypto = 16,
         /// <summary>
         /// Vivaldi
+        /// <para>※各版本共用同一資料夾</para>
         /// </summary>
-        Vivaldi = 7,
+        Vivaldi = 17,
         /// <summary>
         /// Mozilla Firefox
+        /// <para>※各版本共用上層資料夾</para>
         /// </summary>
-        MozillaFirefox = 8
+        MozillaFirefox = 18
     };
 
     /// <summary>
@@ -150,11 +193,21 @@ public class BrowserManager
         return browserType switch
         {
             BrowserType.Brave => @"BraveSoftware\Brave-Browser",
+            BrowserType.BraveBeta => @"BraveSoftware\Brave-Browser-Beta",
+            BrowserType.BraveNightly => @"BraveSoftware\Brave-Browser-Nightly",
             BrowserType.GoogleChrome => @"Google\Chrome",
+            BrowserType.GoogleChromeBeta => @"Google\Chrome Beta",
+            BrowserType.GoogleChromeCanary => @"Google\Chrome SxS",
             BrowserType.Chromium => @"Chromium",
             BrowserType.MicrosoftEdge => @"Microsoft\Edge",
+            BrowserType.MicrosoftEdgeInsiderBeta => @"Microsoft\Edge Beta",
+            BrowserType.MicrosoftEdgeInsiderDev => @"Microsoft\Edge Dev",
+            BrowserType.MicrosoftEdgeInsiderCanary => @"Microsoft\Edge SxS",
             BrowserType.Opera => @"Opera Software\Opera Stable",
+            BrowserType.OperaBeta => @"Opera Software\Opera Next",
+            BrowserType.OperaDeveloper => @"Opera Software\Opera Developer",
             BrowserType.OperaGX => @"Opera Software\Opera GX Stable",
+            BrowserType.OperaCrypto => @"Opera Software\Opera Crypto Stable",
             BrowserType.Vivaldi => "Vivaldi",
             BrowserType.MozillaFirefox => @"Mozilla\Firefox\Profiles",
             _ => @"Google\Chrome"
@@ -309,14 +362,14 @@ public class BrowserManager
         /// <summary>
         /// 取得金鑰
         /// </summary>
-        /// <param name="browser">Browser</param>
+        /// <param name="browserType">BrowserType</param>
         /// <returns>字串</returns>
-        public static byte[] GetKey(BrowserType browser)
+        public static byte[] GetKey(BrowserType browserType)
         {
             //string sR = string.Empty;
             //string appdata = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
 
-            string path = $@"C:\Users\{Environment.UserName}\AppData\Local\{GetPartialPath(browser)}\User Data\Local State";
+            string path = $@"C:\Users\{Environment.UserName}\AppData\Local\{GetPartialPath(browserType)}\User Data\Local State";
             string v = File.ReadAllText(path);
 
             JsonElement json = JsonSerializer.Deserialize<JsonElement>(v);

--- a/Extensions/ControlExtension.cs
+++ b/Extensions/ControlExtension.cs
@@ -9,7 +9,8 @@ public static class ControlExtension
 {
     /// <summary>
     /// 非同步委派更新 UI
-    /// <para>來源：https://dotblogs.com.tw/shinli/2015/04/16/151076 </para>
+    /// <para>來源：https://dotblogs.com.tw/shinli/2015/04/16/151076</para>
+    /// <para>原作者：Shin.Li</para>
     /// </summary>
     /// <param name="control">Control</param>
     /// <param name="action">MethodInvoker</param>

--- a/Extensions/ImageExtension.cs
+++ b/Extensions/ImageExtension.cs
@@ -9,7 +9,11 @@ public static class ImageExtension
 {
     /// <summary>
     /// 將 Image 轉換成 Stream
-    /// <para>來源：https://stackoverflow.com/a/1668493 </para>
+    /// <para>來源：https://stackoverflow.com/a/1668493</para>
+    /// <para>原作者：JaredPar</para>
+    /// <para>編輯者：Kristian Frost</para>
+    /// <para>原授權：CC BY-SA 3.0</para>
+    /// <para>CC BY-SA 3.0：https://creativecommons.org/licenses/by-sa/3.0/</para>
     /// </summary>
     /// <param name="image">Image</param>
     /// <param name="format">ImageFormat</param>

--- a/Extensions/ListViewExtension.cs
+++ b/Extensions/ListViewExtension.cs
@@ -2,7 +2,10 @@
 
 /// <summary>
 /// ListView 的擴充方法
-/// <para>來源：https://stackoverflow.com/a/40205173 </para>
+/// <para>來源：https://stackoverflow.com/a/40205173</para>
+/// <para>原作者：Joe Savage</para>
+/// <para>原授權：CC BY-SA 3.0</para>
+/// <para>CC BY-SA 3.0：https://creativecommons.org/licenses/by-sa/3.0/</para>
 /// </summary>
 public static class ListViewExtension
 {

--- a/FMain.Designer.cs
+++ b/FMain.Designer.cs
@@ -172,7 +172,7 @@ namespace YTLiveChatCatcher
             LVLiveChatList.HeaderStyle = ColumnHeaderStyle.Nonclickable;
             LVLiveChatList.Location = new Point(12, 137);
             LVLiveChatList.Name = "LVLiveChatList";
-            LVLiveChatList.Size = new Size(936, 305);
+            LVLiveChatList.Size = new Size(961, 305);
             LVLiveChatList.TabIndex = 21;
             LVLiveChatList.UseCompatibleStateImageBehavior = false;
             LVLiveChatList.View = View.Details;
@@ -203,14 +203,14 @@ namespace YTLiveChatCatcher
             // 
             // PBProgress
             // 
-            PBProgress.Location = new Point(849, 577);
+            PBProgress.Location = new Point(873, 576);
             PBProgress.Name = "PBProgress";
             PBProgress.Size = new Size(100, 23);
             PBProgress.TabIndex = 40;
             // 
             // BtnClear
             // 
-            BtnClear.Location = new Point(874, 108);
+            BtnClear.Location = new Point(898, 108);
             BtnClear.Name = "BtnClear";
             BtnClear.Size = new Size(75, 23);
             BtnClear.TabIndex = 27;
@@ -397,7 +397,7 @@ namespace YTLiveChatCatcher
             // 
             TBProfileFolderName.Location = new Point(791, 80);
             TBProfileFolderName.Name = "TBProfileFolderName";
-            TBProfileFolderName.Size = new Size(156, 23);
+            TBProfileFolderName.Size = new Size(182, 23);
             TBProfileFolderName.TabIndex = 16;
             TBProfileFolderName.TextChanged += TBProfileFolderName_TextChanged;
             // 
@@ -406,10 +406,10 @@ namespace YTLiveChatCatcher
             CBBrowser.DropDownStyle = ComboBoxStyle.DropDownList;
             CBBrowser.FormattingEnabled = true;
             CBBrowser.ItemHeight = 15;
-            CBBrowser.Items.AddRange(new object[] { "Brave", "Google Chrome", "Chromium", "Microsoft Edge", "Opera", "Opera GX", "Vivaldi", "Mozilla Firefox" });
+            CBBrowser.Items.AddRange(new object[] { "Brave", "Brave Beta", "Brave Nightly", "Google Chrome", "Google Chrome Beta", "Google Chrome Canary", "Chromium", "Microsoft Edge", "Microsoft Edge Insider Beta", "Microsoft Edge Insider Dev", "Microsoft Edge Insider Canary", "Opera", "Opera Beta", "Opera Developer", "Opera GX", "Opera Crypto", "Vivaldi", "Mozilla Firefox" });
             CBBrowser.Location = new Point(792, 33);
             CBBrowser.Name = "CBBrowser";
-            CBBrowser.Size = new Size(156, 23);
+            CBBrowser.Size = new Size(181, 23);
             CBBrowser.TabIndex = 14;
             CBBrowser.SelectedIndexChanged += CBBrowser_SelectedIndexChanged;
             // 
@@ -480,7 +480,7 @@ namespace YTLiveChatCatcher
             // 
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
-            ClientSize = new Size(985, 610);
+            ClientSize = new Size(994, 611);
             Controls.Add(BtnOpenVideoUrl);
             Controls.Add(BtnImport);
             Controls.Add(BtnSearch);
@@ -532,33 +532,33 @@ namespace YTLiveChatCatcher
 
         #endregion
 
-        private System.Windows.Forms.Button BtnStart;
-        private System.Windows.Forms.TextBox TBLog;
-        private System.Windows.Forms.TextBox TBChannelID;
-        private System.Windows.Forms.Button BtnStop;
-        private System.Windows.Forms.TextBox TBVideoID;
-        private System.Windows.Forms.Label LLiveChat;
-        private System.Windows.Forms.Label LChannelID;
-        private System.Windows.Forms.Label LVideoID;
-        private System.Windows.Forms.TextBox TBInterval;
-        private System.Windows.Forms.Label LInterval;
-        private System.Windows.Forms.ListView LVLiveChatList;
-        private System.Windows.Forms.Label LLog;
-        private System.Windows.Forms.Button BtnExport;
-        private System.Windows.Forms.ProgressBar PBProgress;
-        private System.Windows.Forms.Button BtnClear;
-        private System.Windows.Forms.RadioButton RBtnStreaming;
-        private System.Windows.Forms.RadioButton RBtnReplay;
-        private System.Windows.Forms.CheckBox CBExportAuthorPhoto;
-        private System.Windows.Forms.Label LChatCount;
-        private System.Windows.Forms.Label LVersion;
-        private System.Windows.Forms.Label LAuthorCount;
-        private System.Windows.Forms.Label LSuperChatCount;
-        private System.Windows.Forms.Label LSuperStickerCount;
-        private System.Windows.Forms.Label LMemberJoinCount;
-        private System.Windows.Forms.Label LMemberInRoomCount;
-        private System.Windows.Forms.CheckBox CBEnableTTS;
-        private System.Windows.Forms.Label LTempIncome;
+        private Button BtnStart;
+        private TextBox TBLog;
+        private TextBox TBChannelID;
+        private Button BtnStop;
+        private TextBox TBVideoID;
+        private Label LLiveChat;
+        private Label LChannelID;
+        private Label LVideoID;
+        private TextBox TBInterval;
+        private Label LInterval;
+        private ListView LVLiveChatList;
+        private Label LLog;
+        private Button BtnExport;
+        private ProgressBar PBProgress;
+        private Button BtnClear;
+        private RadioButton RBtnStreaming;
+        private RadioButton RBtnReplay;
+        private CheckBox CBExportAuthorPhoto;
+        private Label LChatCount;
+        private Label LVersion;
+        private Label LAuthorCount;
+        private Label LSuperChatCount;
+        private Label LSuperStickerCount;
+        private Label LMemberJoinCount;
+        private Label LMemberInRoomCount;
+        private CheckBox CBEnableTTS;
+        private Label LTempIncome;
         private Label LUserAgent;
         private TextBox TBUserAgent;
         private CheckBox CBRandomInterval;

--- a/FMain.Methods.cs
+++ b/FMain.Methods.cs
@@ -1,5 +1,4 @@
 ﻿using GetCachable;
-using Microsoft.Extensions.Logging;
 using NLog;
 using OfficeOpenXml;
 using OfficeOpenXml.Drawing;
@@ -7,9 +6,11 @@ using OfficeOpenXml.Drawing.Chart;
 using OfficeOpenXml.Drawing.Chart.Style;
 using OfficeOpenXml.Style;
 using OfficeOpenXml.Style.XmlAccess;
+using System.Diagnostics;
 using System.Drawing.Imaging;
 using System.Reflection;
 using System.Runtime.Versioning;
+using System.Windows.Forms.VisualStyles;
 using YTApi;
 using YTApi.Models;
 using YTLiveChatCatcher.Common;
@@ -1036,7 +1037,7 @@ public partial class FMain
 
         bool enableDebug = Properties.Settings.Default.EnableDebug;
 
-        if(enableDebug)
+        if (enableDebug)
         {
             LogManager.ResumeLogging();
         }
@@ -1185,10 +1186,9 @@ public partial class FMain
         {
             try
             {
-                if (SharedCancellationToken.HasValue &&
-                    !SharedCancellationToken.Value.IsCancellationRequested)
+                if (SharedCancellationToken?.IsCancellationRequested == false)
                 {
-                    if (SharedYTConfig != null)
+                    if (SharedYTConfigData != null)
                     {
                         string userAgent = string.Empty;
 
@@ -1204,7 +1204,7 @@ public partial class FMain
 
                         SharedJsonElement = LiveChatFunction.GetJsonElement(
                             httpClient,
-                            SharedYTConfig,
+                            SharedYTConfigData,
                             IsStreaming,
                             GetCookies(),
                             TBLog);
@@ -1213,15 +1213,15 @@ public partial class FMain
                         if (!string.IsNullOrEmpty(SharedJsonElement.ToString()))
                         {
                             // 2021-12-10
-                            // 可能會因為 BtnStop_Click() 造成 SharedYTConfig 為 null。
-                            // 再次檢查 SharedYTConfig 是否為 null。
-                            if (SharedYTConfig != null)
+                            // 可能會因為 BtnStop_Click() 造成 SharedYTConfigData 為 null。
+                            // 再次檢查 SharedYTConfigData 是否為 null。
+                            if (SharedYTConfigData != null)
                             {
                                 // 0：continuation、1：timeoutMs。
                                 string[] continuationData = JsonParser.GetContinuation(SharedJsonElement);
 
                                 // 更換 Continuation。
-                                SharedYTConfig.Continuation = continuationData[0];
+                                SharedYTConfigData.Continuation = continuationData[0];
 
                                 if (int.TryParse(continuationData[1], out int timeoutMs))
                                 {
@@ -2303,17 +2303,84 @@ public partial class FMain
 
                 CBBrowser.InvokeIfRequired(() =>
                 {
-                    List<BrowserManager.CookieData> cookies = CBBrowser.SelectedItem.ToString() switch
+                    List<WebBrowserUtil.CookieData> cookies = CBBrowser.SelectedItem.ToString() switch
                     {
-                        "Brave" => BrowserManager.GetCookies(BrowserManager.BrowserType.Brave, profileFolderName, ".youtube.com"),
-                        "Google Chrome" => BrowserManager.GetCookies(BrowserManager.BrowserType.GoogleChrome, profileFolderName, ".youtube.com"),
-                        "Chromium" => BrowserManager.GetCookies(BrowserManager.BrowserType.Chromium, profileFolderName, ".youtube.com"),
-                        "Microsoft Edge" => BrowserManager.GetCookies(BrowserManager.BrowserType.MicrosoftEdge, profileFolderName, ".youtube.com"),
-                        "Opera" => BrowserManager.GetCookies(BrowserManager.BrowserType.Opera, profileFolderName, ".youtube.com"),
-                        "Opera GX" => BrowserManager.GetCookies(BrowserManager.BrowserType.OperaGX, profileFolderName, ".youtube.com"),
-                        "Vivaldi" => BrowserManager.GetCookies(BrowserManager.BrowserType.Vivaldi, profileFolderName, ".youtube.com"),
-                        "Mozilla Firefox" => BrowserManager.GetCookies(BrowserManager.BrowserType.MozillaFirefox, profileFolderName, ".youtube.com"),
-                        _ => BrowserManager.GetCookies(BrowserManager.BrowserType.GoogleChrome, profileFolderName, ".youtube.com")
+                        "Brave" => WebBrowserUtil.GetCookies(
+                            WebBrowserUtil.BrowserType.Brave,
+                            profileFolderName,
+                            ".youtube.com"),
+                        "Brave Beta" => WebBrowserUtil.GetCookies(
+                            WebBrowserUtil.BrowserType.BraveBeta,
+                            profileFolderName,
+                            ".youtube.com"),
+                        "Brave Nightly" => WebBrowserUtil.GetCookies(
+                            WebBrowserUtil.BrowserType.BraveNightly,
+                            profileFolderName,
+                            ".youtube.com"),
+                        "Google Chrome" => WebBrowserUtil.GetCookies(
+                            WebBrowserUtil.BrowserType.GoogleChrome,
+                            profileFolderName,
+                            ".youtube.com"),
+                        "Google Chrome Beta" => WebBrowserUtil.GetCookies(
+                            WebBrowserUtil.BrowserType.GoogleChromeBeta,
+                            profileFolderName,
+                            ".youtube.com"),
+                        "Google Chrome Canary" => WebBrowserUtil.GetCookies(
+                            WebBrowserUtil.BrowserType.GoogleChromeCanary,
+                            profileFolderName,
+                            ".youtube.com"),
+                        "Chromium" => WebBrowserUtil.GetCookies(
+                            WebBrowserUtil.BrowserType.Chromium,
+                            profileFolderName,
+                            ".youtube.com"),
+                        "Microsoft Edge" => WebBrowserUtil.GetCookies(
+                            WebBrowserUtil.BrowserType.MicrosoftEdge,
+                            profileFolderName,
+                            ".youtube.com"),
+                        "Microsoft Edge Insider Beta" => WebBrowserUtil.GetCookies(
+                            WebBrowserUtil.BrowserType.MicrosoftEdgeInsiderBeta,
+                            profileFolderName,
+                            ".youtube.com"),
+                        "Microsoft Edge Insider Dev" => WebBrowserUtil.GetCookies(
+                            WebBrowserUtil.BrowserType.MicrosoftEdgeInsiderDev,
+                            profileFolderName,
+                            ".youtube.com"),
+                        "Microsoft Edge Insider Canary" => WebBrowserUtil.GetCookies(
+                            WebBrowserUtil.BrowserType.MicrosoftEdgeInsiderCanary,
+                            profileFolderName,
+                            ".youtube.com"),
+                        "Opera" => WebBrowserUtil.GetCookies(
+                            WebBrowserUtil.BrowserType.Opera,
+                            profileFolderName,
+                            ".youtube.com"),
+                        "Opera Beta" => WebBrowserUtil.GetCookies(
+                            WebBrowserUtil.BrowserType.OperaBeta,
+                            profileFolderName,
+                            ".youtube.com"),
+                        "Opera Developer" => WebBrowserUtil.GetCookies(
+                            WebBrowserUtil.BrowserType.OperaDeveloper,
+                            profileFolderName,
+                            ".youtube.com"),
+                        "Opera GX" => WebBrowserUtil.GetCookies(
+                            WebBrowserUtil.BrowserType.OperaGX,
+                            profileFolderName,
+                            ".youtube.com"),
+                        "Opera Crypto" => WebBrowserUtil.GetCookies(
+                            WebBrowserUtil.BrowserType.OperaCrypto,
+                            profileFolderName,
+                            ".youtube.com"),
+                        "Vivaldi" => WebBrowserUtil.GetCookies(
+                            WebBrowserUtil.BrowserType.Vivaldi,
+                            profileFolderName,
+                            ".youtube.com"),
+                        "Mozilla Firefox" => WebBrowserUtil.GetCookies(
+                            WebBrowserUtil.BrowserType.MozillaFirefox,
+                            profileFolderName,
+                            ".youtube.com"),
+                        _ => WebBrowserUtil.GetCookies(
+                            WebBrowserUtil.BrowserType.GoogleChrome,
+                            profileFolderName,
+                            ".youtube.com")
                     };
 
                     cookiesStr = string.Join(";", cookies.Select(n => $"{n.Name}={n.Value}"));

--- a/FMain.Methods.cs
+++ b/FMain.Methods.cs
@@ -6,11 +6,9 @@ using OfficeOpenXml.Drawing.Chart;
 using OfficeOpenXml.Drawing.Chart.Style;
 using OfficeOpenXml.Style;
 using OfficeOpenXml.Style.XmlAccess;
-using System.Diagnostics;
 using System.Drawing.Imaging;
 using System.Reflection;
 using System.Runtime.Versioning;
-using System.Windows.Forms.VisualStyles;
 using YTApi;
 using YTApi.Models;
 using YTLiveChatCatcher.Common;
@@ -1218,7 +1216,7 @@ public partial class FMain
                             if (SharedYTConfigData != null)
                             {
                                 // 0：continuation、1：timeoutMs。
-                                string[] continuationData = JsonParser.GetContinuation(SharedJsonElement);
+                                string[] continuationData = JsonParser.ParseContinuation(SharedJsonElement);
 
                                 // 更換 Continuation。
                                 SharedYTConfigData.Continuation = continuationData[0];
@@ -1235,7 +1233,7 @@ public partial class FMain
 
                             bool isLarge = true;
 
-                            List<RendererData> messages = JsonParser.GetActions(SharedJsonElement, isLarge);
+                            List<RendererData> messages = JsonParser.ParseActions(SharedJsonElement, isLarge);
 
                             foreach (RendererData rendererData in messages)
                             {

--- a/FMain.Variables.cs
+++ b/FMain.Variables.cs
@@ -17,7 +17,7 @@ public partial class FMain
     private int SharedTimeoutMs = 0;
     private System.Windows.Forms.Timer? SharedTimer;
     private JsonElement? SharedJsonElement = new();
-    private YTConfig? SharedYTConfig = null;
+    private YTConfigData? SharedYTConfigData = null;
     private Task? SharedTask = null;
     private CancellationToken? SharedCancellationToken = null;
     private CancellationTokenSource? SharedCancellationTokenSource = null;

--- a/FMain.cs
+++ b/FMain.cs
@@ -297,7 +297,7 @@ public partial class FMain : Form
                             _httpClientFactory,
                             userAgent);
 
-                        SharedYTConfig = LiveChatFunction.GetYTConfig(
+                        SharedYTConfigData = LiveChatFunction.GetYTConfigData(
                             httpClient,
                             videoID,
                             IsStreaming,
@@ -356,7 +356,7 @@ public partial class FMain : Form
             // 清理全域變數。
             SharedJsonElement = new();
 
-            SharedYTConfig = null;
+            SharedYTConfigData = null;
 
             SharedTimeoutMs = 0;
 
@@ -478,7 +478,7 @@ public partial class FMain : Form
             using HttpClient httpClient = HttpClientUtil
                 .GetHttpClient(_httpClientFactory, userAgent);
 
-            if (HttpClientUtil.CheckUserAgent(httpClient, TBUserAgent.Text))
+            if (HttpClientUtil.SetUserAgent(httpClient, TBUserAgent.Text))
             {
                 if (TBUserAgent.Text != Properties.Settings.Default.UserAgent)
                 {

--- a/FMain.resx
+++ b/FMain.resx
@@ -1,4 +1,64 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema 
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing"">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">

--- a/FSearch.Designer.cs
+++ b/FSearch.Designer.cs
@@ -28,115 +28,114 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.LKeyword = new System.Windows.Forms.Label();
-            this.TBKeyword = new System.Windows.Forms.TextBox();
-            this.BtnSearch = new System.Windows.Forms.Button();
-            this.BtnClear = new System.Windows.Forms.Button();
-            this.LVFilteredList = new System.Windows.Forms.ListView();
-            this.LChatCount = new System.Windows.Forms.Label();
-            this.PBProgress = new System.Windows.Forms.ProgressBar();
-            this.BtnExport = new System.Windows.Forms.Button();
-            this.SuspendLayout();
+            LKeyword = new Label();
+            TBKeyword = new TextBox();
+            BtnSearch = new Button();
+            BtnClear = new Button();
+            LVFilteredList = new ListView();
+            LChatCount = new Label();
+            PBProgress = new ProgressBar();
+            BtnExport = new Button();
+            SuspendLayout();
             // 
             // LKeyword
             // 
-            this.LKeyword.AutoSize = true;
-            this.LKeyword.Font = new System.Drawing.Font("Microsoft JhengHei UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-            this.LKeyword.Location = new System.Drawing.Point(12, 9);
-            this.LKeyword.Name = "LKeyword";
-            this.LKeyword.Size = new System.Drawing.Size(43, 15);
-            this.LKeyword.TabIndex = 0;
-            this.LKeyword.Text = "關鍵字";
+            LKeyword.AutoSize = true;
+            LKeyword.Font = new Font("Microsoft JhengHei UI", 9F, FontStyle.Bold, GraphicsUnit.Point);
+            LKeyword.Location = new Point(12, 9);
+            LKeyword.Name = "LKeyword";
+            LKeyword.Size = new Size(43, 15);
+            LKeyword.TabIndex = 0;
+            LKeyword.Text = "關鍵字";
             // 
             // TBKeyword
             // 
-            this.TBKeyword.Location = new System.Drawing.Point(12, 27);
-            this.TBKeyword.Name = "TBKeyword";
-            this.TBKeyword.Size = new System.Drawing.Size(788, 23);
-            this.TBKeyword.TabIndex = 1;
+            TBKeyword.Location = new Point(12, 27);
+            TBKeyword.Name = "TBKeyword";
+            TBKeyword.Size = new Size(799, 23);
+            TBKeyword.TabIndex = 1;
             // 
             // BtnSearch
             // 
-            this.BtnSearch.Location = new System.Drawing.Point(806, 27);
-            this.BtnSearch.Name = "BtnSearch";
-            this.BtnSearch.Size = new System.Drawing.Size(75, 23);
-            this.BtnSearch.TabIndex = 2;
-            this.BtnSearch.Text = "搜尋";
-            this.BtnSearch.UseVisualStyleBackColor = true;
-            this.BtnSearch.Click += new System.EventHandler(this.BtnSearch_Click);
+            BtnSearch.Location = new Point(817, 27);
+            BtnSearch.Name = "BtnSearch";
+            BtnSearch.Size = new Size(75, 23);
+            BtnSearch.TabIndex = 2;
+            BtnSearch.Text = "搜尋";
+            BtnSearch.UseVisualStyleBackColor = true;
+            BtnSearch.Click += BtnSearch_Click;
             // 
             // BtnClear
             // 
-            this.BtnClear.Location = new System.Drawing.Point(887, 26);
-            this.BtnClear.Name = "BtnClear";
-            this.BtnClear.Size = new System.Drawing.Size(75, 23);
-            this.BtnClear.TabIndex = 3;
-            this.BtnClear.Text = "清除";
-            this.BtnClear.UseVisualStyleBackColor = true;
-            this.BtnClear.Click += new System.EventHandler(this.BtnClear_Click);
+            BtnClear.Location = new Point(898, 26);
+            BtnClear.Name = "BtnClear";
+            BtnClear.Size = new Size(75, 23);
+            BtnClear.TabIndex = 3;
+            BtnClear.Text = "清除";
+            BtnClear.UseVisualStyleBackColor = true;
+            BtnClear.Click += BtnClear_Click;
             // 
             // LVFilteredList
             // 
-            this.LVFilteredList.FullRowSelect = true;
-            this.LVFilteredList.GridLines = true;
-            this.LVFilteredList.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
-            this.LVFilteredList.Location = new System.Drawing.Point(12, 56);
-            this.LVFilteredList.Name = "LVFilteredList";
-            this.LVFilteredList.Size = new System.Drawing.Size(950, 194);
-            this.LVFilteredList.TabIndex = 4;
-            this.LVFilteredList.UseCompatibleStateImageBehavior = false;
-            this.LVFilteredList.View = System.Windows.Forms.View.Details;
-            this.LVFilteredList.MouseClick += new System.Windows.Forms.MouseEventHandler(this.LVFilteredList_MouseClick);
-            this.LVFilteredList.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.LVFilteredList_MouseDoubleClick);
+            LVFilteredList.FullRowSelect = true;
+            LVFilteredList.GridLines = true;
+            LVFilteredList.HeaderStyle = ColumnHeaderStyle.Nonclickable;
+            LVFilteredList.Location = new Point(12, 56);
+            LVFilteredList.Name = "LVFilteredList";
+            LVFilteredList.Size = new Size(961, 204);
+            LVFilteredList.TabIndex = 4;
+            LVFilteredList.UseCompatibleStateImageBehavior = false;
+            LVFilteredList.View = View.Details;
+            LVFilteredList.MouseClick += LVFilteredList_MouseClick;
+            LVFilteredList.MouseDoubleClick += LVFilteredList_MouseDoubleClick;
             // 
             // LChatCount
             // 
-            this.LChatCount.AutoSize = true;
-            this.LChatCount.Font = new System.Drawing.Font("Microsoft JhengHei UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-            this.LChatCount.Location = new System.Drawing.Point(12, 264);
-            this.LChatCount.Name = "LChatCount";
-            this.LChatCount.Size = new System.Drawing.Size(89, 15);
-            this.LChatCount.TabIndex = 5;
-            this.LChatCount.Text = "留言數量：0 個";
+            LChatCount.AutoSize = true;
+            LChatCount.Font = new Font("Microsoft JhengHei UI", 9F, FontStyle.Bold, GraphicsUnit.Point);
+            LChatCount.Location = new Point(12, 274);
+            LChatCount.Name = "LChatCount";
+            LChatCount.Size = new Size(89, 15);
+            LChatCount.TabIndex = 5;
+            LChatCount.Text = "留言數量：0 個";
             // 
             // PBProgress
             // 
-            this.PBProgress.Location = new System.Drawing.Point(862, 256);
-            this.PBProgress.Name = "PBProgress";
-            this.PBProgress.Size = new System.Drawing.Size(100, 23);
-            this.PBProgress.TabIndex = 6;
+            PBProgress.Location = new Point(873, 266);
+            PBProgress.Name = "PBProgress";
+            PBProgress.Size = new Size(100, 23);
+            PBProgress.TabIndex = 6;
             // 
             // BtnExport
             // 
-            this.BtnExport.Location = new System.Drawing.Point(781, 256);
-            this.BtnExport.Name = "BtnExport";
-            this.BtnExport.Size = new System.Drawing.Size(75, 23);
-            this.BtnExport.TabIndex = 7;
-            this.BtnExport.Text = "匯出 *.xlsx";
-            this.BtnExport.UseVisualStyleBackColor = true;
-            this.BtnExport.Click += new System.EventHandler(this.BtnExport_Click);
+            BtnExport.Location = new Point(792, 266);
+            BtnExport.Name = "BtnExport";
+            BtnExport.Size = new Size(75, 23);
+            BtnExport.TabIndex = 7;
+            BtnExport.Text = "匯出 *.xlsx";
+            BtnExport.UseVisualStyleBackColor = true;
+            BtnExport.Click += BtnExport_Click;
             // 
             // FSearch
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(985, 295);
-            this.Controls.Add(this.BtnExport);
-            this.Controls.Add(this.PBProgress);
-            this.Controls.Add(this.LChatCount);
-            this.Controls.Add(this.LVFilteredList);
-            this.Controls.Add(this.BtnClear);
-            this.Controls.Add(this.BtnSearch);
-            this.Controls.Add(this.TBKeyword);
-            this.Controls.Add(this.LKeyword);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-            this.MaximizeBox = false;
-            this.Name = "FSearch";
-            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.FSearch_FormClosing);
-            this.Load += new System.EventHandler(this.FSearch_Load);
-            this.ResumeLayout(false);
-            this.PerformLayout();
-
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new Size(994, 301);
+            Controls.Add(BtnExport);
+            Controls.Add(PBProgress);
+            Controls.Add(LChatCount);
+            Controls.Add(LVFilteredList);
+            Controls.Add(BtnClear);
+            Controls.Add(BtnSearch);
+            Controls.Add(TBKeyword);
+            Controls.Add(LKeyword);
+            FormBorderStyle = FormBorderStyle.FixedSingle;
+            MaximizeBox = false;
+            Name = "FSearch";
+            FormClosing += FSearch_FormClosing;
+            Load += FSearch_Load;
+            ResumeLayout(false);
+            PerformLayout();
         }
 
         #endregion

--- a/FSearch.resx
+++ b/FSearch.resx
@@ -1,4 +1,64 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema 
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing"">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">

--- a/Program.cs
+++ b/Program.cs
@@ -29,7 +29,7 @@ internal static class Program
 
     /// <summary>
     /// 設定服務
-    /// <para>參考：https://docs.microsoft.com/zh-tw/archive/msdn-magazine/2019/may/net-core-3-0-create-a-centralized-pull-request-hub-with-winforms-in-net-core-3-0 </para>
+    /// <para>來源：https://docs.microsoft.com/zh-tw/archive/msdn-magazine/2019/may/net-core-3-0-create-a-centralized-pull-request-hub-with-winforms-in-net-core-3-0 </para>
     /// </summary>
     private static void ConfigureServices()
     {
@@ -75,7 +75,10 @@ internal static class Program
 
     /// <summary>
     /// 更新設定
-    /// <para>來源：https://stackoverflow.com/a/23924277 </para>
+    /// <para>來源：https://stackoverflow.com/a/23924277</para>
+    /// <para>原作者：Grant</para>
+    /// <para>原授權：CC BY-SA 3.0</para>
+    /// <para>CC BY-SA 3.0：https://creativecommons.org/licenses/by-sa/3.0/</para>
     /// </summary>
     private static void UpdateConfig()
     {

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -50,7 +50,7 @@ namespace YTLiveChatCatcher.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("1")]
+        [global::System.Configuration.DefaultSettingValueAttribute("3")]
         public int BrowserItemIndex {
             get {
                 return ((int)(this["BrowserItemIndex"]));

--- a/Properties/Settings.settings
+++ b/Properties/Settings.settings
@@ -9,7 +9,7 @@
       <Value Profile="(Default)">Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36</Value>
     </Setting>
     <Setting Name="BrowserItemIndex" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">1</Value>
+      <Value Profile="(Default)">3</Value>
     </Setting>
     <Setting Name="ProfileFolderName" Type="System.String" Scope="User">
       <Value Profile="(Default)" />

--- a/YTApi/Extensions/JsonElementExtension.cs
+++ b/YTApi/Extensions/JsonElementExtension.cs
@@ -4,7 +4,10 @@ namespace YTApi.Extensions;
 
 /// <summary>
 /// JsonElement 的擴充方法
-/// <para>來源：https://stackoverflow.com/a/61561343 </para>
+/// <para>來源：https://stackoverflow.com/a/61561343</para>
+/// <para>原作者：dbc</para>
+/// <para>原授權：CC BY-SA 4.0</para>
+/// <para>CC BY-SA 4.0：https://creativecommons.org/licenses/by-sa/4.0/</para>
 /// </summary>
 public static partial class JsonElementExtension
 {

--- a/YTApi/JsonParser.cs
+++ b/YTApi/JsonParser.cs
@@ -68,7 +68,7 @@ public partial class JsonParser
             }
 
             ytConfigData.SessionIndex = jeSessionIndex?.GetString();
-            ytConfigData.InnetrubeContextClientName = jeInnertubeContextClientName?.GetInt32().ToString();
+            ytConfigData.InnetrubeContextClientName = jeInnertubeContextClientName?.GetInt32() ?? 0;
             ytConfigData.InnetrubeContextClientVersion = jeInnertubeContextClientVersion?.GetString();
             ytConfigData.InnetrubeClientVersion = jeInnertubeClientVersion?.GetString();
 

--- a/YTApi/JsonParser.cs
+++ b/YTApi/JsonParser.cs
@@ -536,7 +536,7 @@ public partial class JsonParser
     {
         List<RendererData> output = new();
 
-        // 參考：https://github.com/xenova/chat-downloader/blob/657e56eeec4ebe5af28de66b4d3653dbb796c8c1/chat_downloader/sites/youtube.py#L926
+        // 參考：https://github.com/xenova/chat-downloader/blob/master/chat_downloader/sites/youtube.py#L969
         if (jsonElement.TryGetProperty(
             "liveChatTextMessageRenderer",
             out JsonElement liveChatTextMessageRenderer))

--- a/YTApi/JsonParser.cs
+++ b/YTApi/JsonParser.cs
@@ -1045,16 +1045,14 @@ public partial class JsonParser
 
                         // 2022-05-18 不再取 "shortcuts" 的第一個值。
                         /*
-                        JsonElement? shortcuts = emoji.Value.Get("shortcuts");
+                        JsonElement.ArrayEnumerator? shortcuts = emoji
+                            ?.Get("shortcuts")
+                            ?.ToArrayEnumerator();
 
-                        if (shortcuts.HasValue &&
-                            shortcuts.Value.ValueKind == JsonValueKind.Array)
+                        if (shortcuts?.Any() == true)
                         {
-                            if (shortcuts.Value.GetArrayLength() > 0)
-                            {
-                                // 只取第一個。
-                                tempStr += $" {shortcuts.Value[0].GetString()} ";
-                            }
+                            // 只取第一個。
+                            tempText += $" {shortcuts?.ElementAtOrDefault(0).GetString()} ";
                         }
                         */
 

--- a/YTApi/LiveChatFunction.cs
+++ b/YTApi/LiveChatFunction.cs
@@ -218,6 +218,9 @@ public partial class LiveChatFunction
             IElement elementYtCfg = scriptElements
                 .FirstOrDefault(n => n.InnerHtml.Contains("ytcfg.set({"))!;
 
+            // TODO: 2023-06-13 考慮是否待修改。
+            // 可以參考 1：https://github.com/abhinavxd/youtube-live-chat-downloader/blob/v1.0.5/yt_chat.go#L140
+            // 可以參考 2：https://github.com/xenova/chat-downloader/blob/master/chat_downloader/sites/youtube.py#L443
             string jsonYtCfg = elementYtCfg.InnerHtml;
 
             if (isStreaming)
@@ -474,7 +477,7 @@ public partial class LiveChatFunction
 
             httpRequestMessage.Headers.Add("X-Goog-Authuser", xGoogAuthuser);
             httpRequestMessage.Headers.Add("X-Goog-Visitor-Id", ytConfigData.VisitorData);
-            httpRequestMessage.Headers.Add("X-Youtube-Client-Name", ytConfigData.InnetrubeContextClientName);
+            httpRequestMessage.Headers.Add("X-Youtube-Client-Name", ytConfigData.InnetrubeContextClientName.ToString());
             httpRequestMessage.Headers.Add("X-Youtube-Client-Version", ytConfigData.InnetrubeClientVersion);
 
             if (!string.IsNullOrEmpty(ytConfigData.InitPage))

--- a/YTApi/LiveChatFunction.cs
+++ b/YTApi/LiveChatFunction.cs
@@ -374,9 +374,7 @@ public partial class LiveChatFunction
         YTConfigData ytConfigData,
         string userAgent)
     {
-        // 2022-05-19 尚未測試會員限定直播是否需要 "clickTracking" 參數。
-        // 2022-05-29 已確認不需要 "clickTracking" 參數。
-        // 參考：https://github.com/xenova/chat-downloader/blob/ff9ddb1f840fa06d0cc3976badf75c1fffebd003/chat_downloader/sites/youtube.py#L1664
+        // 參考：https://github.com/xenova/chat-downloader/blob/master/chat_downloader/sites/youtube.py#L1764
         // 參考：https://github.com/abhinavxd/youtube-live-chat-downloader/blob/main/yt_chat.go
 
         // 內容是精簡過的。
@@ -408,7 +406,10 @@ public partial class LiveChatFunction
 
     /// <summary>
     /// 設定 HttpRequestMessage 的標頭
-    /// <para>參考：https://stackoverflow.com/questions/12373738/how-do-i-set-a-cookie-on-httpclients-httprequestmessage/13287224#13287224 </para>
+    /// <para>來源：https://stackoverflow.com/a/13287224</para>
+    /// <para>原作者：Greg Beech</para>
+    /// <para>原授權：CC BY-SA 3.0</para>
+    /// <para>CC BY-SA 3.0：https://creativecommons.org/licenses/by-sa/3.0/</para>
     /// </summary>
     /// <param name="httpRequestMessage">HttpRequestMessage</param>
     /// <param name="cookies">字串，Cookies</param>

--- a/YTApi/Models/RequestPayloadData.cs
+++ b/YTApi/Models/RequestPayloadData.cs
@@ -2,7 +2,7 @@
 
 namespace YTApi.Models;
 
-public class RequestPayload
+public class RequestPayloadData
 {
     [JsonPropertyName("context")]
     public Context? Context { get; set; }

--- a/YTApi/Models/YTConfigData.cs
+++ b/YTApi/Models/YTConfigData.cs
@@ -58,7 +58,7 @@ public class YTConfigData
     /// <summary>
     /// INNERTUBE_CONTEXT_CLIENT_NAME
     /// </summary>
-    public string? InnetrubeContextClientName { get; set; }
+    public int InnetrubeContextClientName { get; set; }
 
     /// <summary>
     /// INNERTUBE_CONTEXT_CLIENT_VERSION

--- a/YTApi/Models/YTConfigData.cs
+++ b/YTApi/Models/YTConfigData.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// 必要資料類別
 /// </summary>
-public class YTConfig
+public class YTConfigData
 {
     /// <summary>
     /// 初始頁面

--- a/YTApi/Models/YTConfigData.cs
+++ b/YTApi/Models/YTConfigData.cs
@@ -38,35 +38,35 @@ public class YTConfigData
     /// <summary>
     /// ID_TOKEN
     /// </summary>
-    public string? ID_TOKEN { get; set; }
+    public string? IDToken { get; set; }
 
     /// <summary>
     /// DATASYNC_ID
     /// </summary>
-    public string? DATASYNC_ID { get; set; }
+    public string? DataSyncID { get; set; }
 
     /// <summary>
     /// DELEGATED_SESSION_ID
     /// </summary>
-    public string? DELEGATED_SESSION_ID { get; set; }
+    public string? DelegatedSessionID { get; set; }
 
     /// <summary>
     /// SESSION_INDEX
     /// </summary>
-    public string? SESSION_INDEX { get; set; }
+    public string? SessionIndex { get; set; }
 
     /// <summary>
     /// INNERTUBE_CONTEXT_CLIENT_NAME
     /// </summary>
-    public string? INNERTUBE_CONTEXT_CLIENT_NAME { get; set; }
+    public string? InnetrubeContextClientName { get; set; }
 
     /// <summary>
     /// INNERTUBE_CONTEXT_CLIENT_VERSION
     /// </summary>
-    public string? INNERTUBE_CONTEXT_CLIENT_VERSION { get; set; }
+    public string? InnetrubeContextClientVersion { get; set; }
 
     /// <summary>
     /// INNERTUBE_CLIENT_VERSION
     /// </summary>
-    public string? INNERTUBE_CLIENT_VERSION { get; set; }
+    public string? InnetrubeClientVersion { get; set; }
 }

--- a/YTLiveChatCatcher.csproj
+++ b/YTLiveChatCatcher.csproj
@@ -19,8 +19,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="AngleSharp" Version="1.0.3" />
-		<PackageReference Include="EPPlus" Version="6.2.4" />
-		<PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.5" />
+		<PackageReference Include="EPPlus" Version="6.2.6" />
+		<PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.7" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="7.0.3" />

--- a/YTLiveChatCatcher.csproj
+++ b/YTLiveChatCatcher.csproj
@@ -18,14 +18,14 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AngleSharp" Version="1.0.3" />
+		<PackageReference Include="AngleSharp" Version="1.0.4" />
 		<PackageReference Include="EPPlus" Version="6.2.6" />
-		<PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.8" />
+		<PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.9" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="7.0.4" />
-		<PackageReference Include="NLog" Version="5.2.0" />
-		<PackageReference Include="NLog.Extensions.Logging" Version="5.3.0" />
+		<PackageReference Include="NLog" Version="5.2.2" />
+		<PackageReference Include="NLog.Extensions.Logging" Version="5.3.2" />
 		<PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
 	</ItemGroup>
 

--- a/YTLiveChatCatcher.csproj
+++ b/YTLiveChatCatcher.csproj
@@ -20,10 +20,10 @@
 	<ItemGroup>
 		<PackageReference Include="AngleSharp" Version="1.0.3" />
 		<PackageReference Include="EPPlus" Version="6.2.6" />
-		<PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.7" />
+		<PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.8" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="7.0.3" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="7.0.4" />
 		<PackageReference Include="NLog" Version="5.2.0" />
 		<PackageReference Include="NLog.Extensions.Logging" Version="5.3.0" />
 		<PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />

--- a/YTLiveChatCatcher.csproj
+++ b/YTLiveChatCatcher.csproj
@@ -7,7 +7,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UseWindowsForms>true</UseWindowsForms>
 		<RootNamespace>YTLiveChatCatcher</RootNamespace>
-		<Version>1.4.9</Version>
+		<Version>1.4.10</Version>
 		<AssemblyName>YTLiveChatCatcher</AssemblyName>
 		<ApplicationIcon>Resources\app_icon_large.ico</ApplicationIcon>
 		<DebugType>embedded</DebugType>


### PR DESCRIPTION
1. 將 BrowserManager.cs 重新命名成 WebBrowserUtil.cs。
2. 調整 HttpClientUtil.cs 內設定使用者代理字串的方式。
3. UI 調整。
4. 將 YTConfig.cs 重新命名成 YTConfigData.cs。
5. 將 RequestPayload.cs 重新命名成 RequestPayloadData.cs。
6. 支援從更多的其他瀏覽器載入 Cookies。
7. 調整 YTConfigData.cs 內屬性的名稱，以符合命名規則。
8. 新增方法 ParseYtCfg()，用以重構先前取得 YTConfigData 的程式碼。
9. 移除不需要的 using。
10. 重新調整部分方法的名稱，以免造成混淆。
11. 修正型別。
12. 修正類型的錯誤，加入類型轉換。
13. 修改以註解的程式碼，以符合現在的寫法。
14. 更新第三方函式庫。
15. 補上漏缺的原著作權宣告。